### PR TITLE
Optimize position groups

### DIFF
--- a/app/src/api/balances.js
+++ b/app/src/api/balances.js
@@ -108,7 +108,7 @@ export const generatePositionList = async (balances) => {
   // e.g. Ay independent of all other outcomes is lowest amount in Ay****
   // AyBy independent of C* is lowest amount in AyBy**
 
-  const positionGroupings = resolvePositionGrouping(outcomePrices.map((price, index) => [outcomePairNames[index], price]))
+  const positionGroupings = resolvePositionGrouping(balances.map((balance, index) => [outcomePairNames[index], balance]))
 
   const positionGroupingsSorted = sortBy(positionGroupings, [([ outcomeIds, value ]) => outcomeIds.length, ([ outcomeIds, value ]) => value ])
 

--- a/app/src/api/balances.js
+++ b/app/src/api/balances.js
@@ -51,7 +51,7 @@ export const loadBalances = async positions => {
     })
   );
 
-  console.log(`position balances: ${JSON.stringify(balancesList)}`);
+  // console.log(`position balances: ${JSON.stringify(balancesList)}`);
 
   return balancesList;
 };
@@ -112,7 +112,7 @@ export const generatePositionList = async (balances) => {
 
   const positionGroupingsSorted = sortBy(positionGroupings, [([ outcomeIds, value ]) => outcomeIds.length, ([ outcomeIds, value ]) => value ])
 
-  console.log(positionGroupingsSorted)
+  // console.log(positionGroupingsSorted)
   return await Promise.all(
     positionGroupingsSorted.map(async ([outcomeIds, value]) => {
       const affectedMarkets = listAffectedMarketsForOutcomeIds(markets, outcomeIds)
@@ -174,7 +174,7 @@ export const sumPricePerShare = async (outcomePairs) => {
 }
 
 export const calcOutcomeTokenCounts = async (outcomePairs, assumedPairs, amount) => {
-  console.log(outcomePairs)
+  // console.log(outcomePairs)
   const { lmsr } = await loadConfig()
 
   const marketOutcomeCounts = await loadMarketOutcomeCounts();
@@ -185,13 +185,13 @@ export const calcOutcomeTokenCounts = async (outcomePairs, assumedPairs, amount)
   const funding = (await LMSR.funding()).toString()
   const lmsrTokenBalances = await loadLmsrTokenBalances(lmsr)
 
-  console.log("selected and assumed")
-  console.log(outcomePairs, assumedPairs)
+  // console.log("selected and assumed")
+  // console.log(outcomePairs, assumedPairs)
 
   const assumedPairIndexes = assumedPairs.map((outcomePair) => outcomePairNames.indexOf(outcomePair))
   const outcomePairsAsIndexes = outcomePairs.map((outcomePair) => outcomePairNames.indexOf(outcomePair))
 
-  console.log(assumedPairIndexes, outcomePairsAsIndexes)
+  // console.log(assumedPairIndexes, outcomePairsAsIndexes)
   const outcomeTokenCounts = await lmsrCalcOutcomeTokenCount(funding, lmsrTokenBalances, outcomePairsAsIndexes, amount, assumedPairIndexes)
   
   return outcomeTokenCounts

--- a/app/src/api/markets.js
+++ b/app/src/api/markets.js
@@ -74,7 +74,7 @@ export const loadMarginalPrices = async () => {
   )
 
 
-  console.log("marginal prices:", atomicOutcomePrices)
+  // console.log("marginal prices:", atomicOutcomePrices)
 
   return atomicOutcomePrices
 }
@@ -84,9 +84,9 @@ export const buyOutcomes = async (buyList) => {
   const { lmsr } = await loadConfig();
   const LMSR = await loadContract("LMSRMarketMaker", lmsr);
   // get market maker instance
-  console.log("buy: ", buyList)
+  // console.log("buy: ", buyList)
   const cost = await LMSR.calcNetCost.call(buyList);
-  console.log("cost: ", cost.toString())
+  // console.log("cost: ", cost.toString())
   
   const defaultAccount = await getDefaultAccount();
   const prev = new Decimal(await getAccountBalance())
@@ -99,19 +99,19 @@ export const buyOutcomes = async (buyList) => {
   // run trade
   const tx = await LMSR.trade(buyList, cost, { from: defaultAccount });
 
-  console.log(tx.receipt.gasUsed)
+  // console.log(tx.receipt.gasUsed)
   const gasPrice = new Decimal(await getGasPrice())
   const gasCost = gasPrice.mul(tx.receipt.gasUsed)
 
   //const wait = await (new Promise((resolve) => setTimeout(resolve, 500)))
 
   const now = prev.plus(gasCost).sub(new Decimal(await getAccountBalance()))
-  console.log(`wei used for tx (excluding gas): ${(await getAccountBalance()).toString()}`)
-  console.log(tx);
+  // console.log(`wei used for tx (excluding gas): ${(await getAccountBalance()).toString()}`)
+  // console.log(tx);
 };
 
 export const sellOutcomes = async (lmsrOutcomeIndexes, amount) => {
-  console.log("TCL: sellOutcomes -> lmsrOutcomeIndexes", lmsrOutcomeIndexes);
+  // console.log("TCL: sellOutcomes -> lmsrOutcomeIndexes", lmsrOutcomeIndexes);
 
   // load all outcome prices
   const { lmsr } = await loadConfig();
@@ -144,7 +144,7 @@ export const sellOutcomes = async (lmsrOutcomeIndexes, amount) => {
 
   //const marketStructure = Array(outcomeSlotCount)
   const { outcomePairs, outcomeIds } = resolvePartitionSets(marketStructure);
-  console.log("TCL: sellOutcomes -> outcomePairs", outcomePairs);
+  // console.log("TCL: sellOutcomes -> outcomePairs", outcomePairs);
 
   // list of outcomePairIndexes we'd like to sell
   const wantList = lmsrOutcomeIndexes.map(
@@ -164,14 +164,14 @@ export const sellOutcomes = async (lmsrOutcomeIndexes, amount) => {
       return pairHasAllWantedOutcomes ? -amount : SHARE_AMOUNT_NONE.toString();
     });
 
-  console.log(`selling "${JSON.stringify(wantList)}" with ${amount} each.`);
-  console.log(`assembled "sellList": "${JSON.stringify(sellList)}"`);
+  // console.log(`selling "${JSON.stringify(wantList)}" with ${amount} each.`);
+  // console.log(`assembled "sellList": "${JSON.stringify(sellList)}"`);
 
   const testSellList = [-1, "0", 0, "0"];
 
   // get market maker instance
   const cost = await LMSR.calcNetCost.call(testSellList);
-  console.log({ cost: cost.toString() });
+  // console.log({ cost: cost.toString() });
 
   const defaultAccount = await getDefaultAccount();
 
@@ -179,11 +179,11 @@ export const sellOutcomes = async (lmsrOutcomeIndexes, amount) => {
   await PMSystem.setApprovalForAll(lmsr, true, {
     from: defaultAccount
   });
-  console.log("approval set");
+  // console.log("approval set");
   // run trade
   const tx = await LMSR.trade(testSellList, cost, {
     from: defaultAccount,
     gas: 0x6691b7
   });
-  console.log(tx);
+  // console.log(tx);
 };

--- a/app/src/api/probabilities.js
+++ b/app/src/api/probabilities.js
@@ -62,7 +62,7 @@ export const getIndividualProbabilities = (
   marketOutcomeCounts,
   assumedOutcomeIndexes,
 ) => {
-  console.log(atomicOutcomePrices)
+  // console.log(atomicOutcomePrices)
   const outcomeIdNames = nameMarketOutcomes(marketOutcomeCounts);
   const outcomePairNames = nameOutcomePairs(outcomeIdNames);
 

--- a/app/src/api/utils/positionGrouping.js
+++ b/app/src/api/utils/positionGrouping.js
@@ -2,7 +2,9 @@ import 'lodash.combinations';
 import { combinations } from 'lodash'
 
 import { cartesian } from './probabilities';
-import Decimal from "decimal.js";
+import Web3 from "web3";
+
+const { toBN } = Web3.utils
 
 /**
  * Generates a grouping of positions to state specific conditions correlation or independance of one-another
@@ -25,13 +27,18 @@ export const resolvePositionGrouping = outcomeHoldingPairs => {
       (numConditions === 0 ? [[]] : [...cartesian(...conditionTuple)]).forEach((cartesianTuple) => {
         const filteredThings = things.filter(([ atomicOutcome, balance ]) => cartesianTuple.every((condition) => atomicOutcome.includes(condition)))
 
-        const minValue = Math.min(...filteredThings.map((something) => something[1]))
+        const minValue = filteredThings.reduce((minSoFar, [, valStr]) => {
+          const nextVal = toBN(valStr)
+          if(minSoFar == null || nextVal.lt(minSoFar))
+            return nextVal
+          return minSoFar
+        }, null)
 
         if (minValue > 0) {
-          output.push([cartesianTuple.join("&"), minValue])
+          output.push([cartesianTuple.join("&"), minValue.toString()])
 
           filteredThings.forEach((filteredthing) => {
-            filteredthing[1] -= minValue
+            filteredthing[1] = toBN(filteredthing[1]).sub(minValue).toString()
           })
         }
       })

--- a/app/src/api/utils/positionGrouping.js
+++ b/app/src/api/utils/positionGrouping.js
@@ -10,7 +10,7 @@ import Decimal from "decimal.js";
  * @param {[[String, Number]]} groups - Balances of all atomic outcomes, in the format of ["AyByCy", 1000]
  */
 export const resolvePositionGrouping = outcomeHoldingPairs => {
-  console.log(outcomeHoldingPairs)
+  // console.log(outcomeHoldingPairs)
 
   // [[["Ay", "By", "Cy"] 1337], ...]
   const things = outcomeHoldingPairs.map(([ atomicOutcome, balance ]) => (

--- a/app/src/api/utils/positions.js
+++ b/app/src/api/utils/positions.js
@@ -25,7 +25,7 @@ function* positionListGenerator(markets, parentCollectionId) {
 
     const collectionId = addWithOverflow(parentCollectionId, marketCollectionId);
     // used to generate a debug-tree of all position id steps
-    //console.log(`${" ".repeat((++indent) * 2)}id: ${collectionId.toString(16).slice(0, 5)}, parent: ${parentCollectionId.toString(16).slice(0, 5)}, market-index: ${newMarkets.length}, outcomeindex: ${outcomeIndex}`)
+    // console.log(`${" ".repeat((++indent) * 2)}id: ${collectionId.toString(16).slice(0, 5)}, parent: ${parentCollectionId.toString(16).slice(0, 5)}, market-index: ${newMarkets.length}, outcomeindex: ${outcomeIndex}`)
 
     yield collectionId.toString(16)
     yield *positionListGenerator(newMarkets, collectionId)

--- a/app/src/api/utils/probabilities.js
+++ b/app/src/api/utils/probabilities.js
@@ -79,7 +79,7 @@ export const getIndividualProbabilities = (
   marketOutcomeCounts,
   assumedOutcomeIndexes,
 ) => {
-  console.log(atomicOutcomePrices)
+  // console.log(atomicOutcomePrices)
   const outcomeIdNames = nameMarketOutcomes(marketOutcomeCounts);
   const outcomePairNames = nameOutcomePairs(outcomeIdNames);
 

--- a/app/src/api/web3.js
+++ b/app/src/api/web3.js
@@ -6,7 +6,7 @@ import config from "../../config.json";
 let provider;
 let isLocal;
 if (process.env.NODE_ENV === "development") {
-  console.log('Using ganache because "NODE_ENV" is in development mode.');
+  // console.log('Using ganache because "NODE_ENV" is in development mode.');
   provider = new Web3("http://localhost:8545");
   isLocal = true;
   
@@ -37,12 +37,12 @@ export const loadContract = async (contractName, address) => {
     let instance;
     if (address) {
       instance = await contract.at(address);
-      console.log(`Loading ${contractName}@${address}`);
-      console.log(instance);
+      // console.log(`Loading ${contractName}@${address}`);
+      // console.log(instance);
     } else {
       instance = await contract.deployed();
-      console.log(`Loading ${contractName}@deployed`);
-      console.log(instance);
+      // console.log(`Loading ${contractName}@deployed`);
+      // console.log(instance);
     }
 
     contracts[path] = instance;
@@ -63,13 +63,13 @@ export const getAccountBalance = async (account) => {
   }
 
   const balance = await provider.eth.getBalance(usedAccount)
-  console.log(`Balance@${usedAccount}: ${balance.toString()}`)
+  // console.log(`Balance@${usedAccount}: ${balance.toString()}`)
   return balance.toString()
 }
 
 export const getGasPrice = async () => {
   const gasPrice = await provider.eth.getGasPrice()
-  console.log(gasPrice)
+  // console.log(gasPrice)
   return gasPrice.toString()
 }
 
@@ -108,7 +108,7 @@ export const loadConfig = async () => {
   const network = await getNetwork();
 
   if (config[network]) {
-    console.log(`Loading configuration for network ${network}`);
+    // console.log(`Loading configuration for network ${network}`);
     loadedConfig = config[network];
     return loadedConfig;
   }

--- a/app/src/components/YourPositions/index.js
+++ b/app/src/components/YourPositions/index.js
@@ -22,13 +22,13 @@ const YourPositions = ({ positions }) => (
             </span>
           )
         ) : (
-          <>
+          <span>
             <strong>{formatFromWei(position.value)}</strong>{" "}
             when{" "}
             {arrayToHumanReadableList(
               position.markets.map(market => market.selectedOutcome === 0 ? pseudoMarkdown(market.when) : pseudoMarkdown(market.whenNot))
             )}
-          </>
+          </span>
         )}
       </div>
     ))}

--- a/app/src/containers/Page/index.js
+++ b/app/src/containers/Page/index.js
@@ -238,8 +238,8 @@ const enhancer = compose(
       const outcomeTokenCounts = await calcOutcomeTokenCounts(outcomePairs, assumedPairs, amount)
       await setOutcomeTokenBuyAmounts(outcomeTokenCounts)
 
-      console.log("tokens purchase list:")
-      console.log(outcomeTokenCounts)
+      // console.log("tokens purchase list:")
+      // console.log(outcomeTokenCounts)
     },
   }),
   withHandlers({
@@ -342,13 +342,13 @@ const enhancer = compose(
           market.outcomes[marketOutcomeIndex].lmsrOutcomeIndex
         );
       });
-      console.log(
-        "handleSellOutcomes -> outcomeIndexes: ",
-        JSON.stringify(outcomeIndexes, null, 2)
-      );
+      // console.log(
+      //   "handleSellOutcomes -> outcomeIndexes: ",
+      //   JSON.stringify(outcomeIndexes, null, 2)
+      // );
       await sellOutcomes(outcomeIndexes, invest);
       const updatedMarkets = await loadMarkets();
-      //console.log(markets)
+      // console.log(markets)
       setMarkets(updatedMarkets);
     },
     handleSellOutcome: ({
@@ -359,7 +359,7 @@ const enhancer = compose(
       const sellAmount = sellAmounts[lmsrOutcomeIndex];
       await sellOutcomes([lmsrOutcomeIndex], sellAmount);
       const updatedMarkets = await loadMarkets();
-      //console.log(markets)
+      // console.log(markets)
       setMarkets(updatedMarkets);
       setSellAmounts(prev => ({
         ...prev,


### PR DESCRIPTION
I could probably take out the silence all console logs commit if that would be better.

Anyway, this is just a small fix-up to the positions grouping. I have some nascent ideas on how to go about grouping positions more aggressively though:

If the current approach is like a Riemann integral, then a more aggressive approach might be "Lebesgue-like". Basically, instead of going from broader events to more narrow events, consider all atomic outcomes grouped by having the same amount, from smallest to largest, and then try to categorize these groups as broadly as possible.