### PR TITLE
Config fixes

### DIFF
--- a/migrations/2_pmSystem_migration.js
+++ b/migrations/2_pmSystem_migration.js
@@ -116,7 +116,7 @@ module.exports = (deployer, network, accounts) => {
         pmSystemInstance.address,
         collateralToken.address,
         [conditionOneId, conditionTwoId, conditionThreeId],
-        1,
+        0,
         process.env.AMMFUNDING || defaultAMMFunding,
         { from: accounts[0] }
       );

--- a/migrations/2_pmSystem_migration.js
+++ b/migrations/2_pmSystem_migration.js
@@ -11,6 +11,7 @@ const Fixed192x64Math = artifacts.require("Fixed192x64Math");
 const WETH9 = artifacts.require("WETH9");
 
 const initialNonce = 0x01;
+const defaultAMMFunding = (1e19).toString();
 
 module.exports = (deployer, network, accounts) => {
   if (network === "development" || network === "test") {
@@ -103,11 +104,11 @@ module.exports = (deployer, network, accounts) => {
       // Deposit the CollateralTokens necessary and approve() the pre-deployed LMSR instance
       await collateralToken.deposit({
         from: accounts[0],
-        value: process.env.AMMFUNDING || 1e12
+        value: process.env.AMMFUNDING || defaultAMMFunding
       });
       await collateralToken.approve(
         checksummedLMSRAddress,
-        process.env.AMMFUNDING || 1e12,
+        process.env.AMMFUNDING || defaultAMMFunding,
         { from: accounts[0] }
       );
       // Deploy the pre-calculated LMSR instance
@@ -116,7 +117,7 @@ module.exports = (deployer, network, accounts) => {
         collateralToken.address,
         [conditionOneId, conditionTwoId, conditionThreeId],
         1,
-        process.env.AMMFUNDING || 1,
+        process.env.AMMFUNDING || defaultAMMFunding,
         { from: accounts[0] }
       );
     });
@@ -226,11 +227,11 @@ module.exports = (deployer, network, accounts) => {
       // Deposit the CollateralTokens necessary and approve() the pre-deployed LMSR instance
       await collateralToken.deposit({
         from: accounts[0],
-        value: process.env.AMMFUNDING || 1e12
+        value: process.env.AMMFUNDING || defaultAMMFunding
       });
       await collateralToken.approve(
         checksummedLMSRAddress,
-        process.env.AMMFUNDING || 1e12,
+        process.env.AMMFUNDING || defaultAMMFunding,
         { from: accounts[0] }
       );
       // Deploy the pre-calculated LMSR instance
@@ -239,7 +240,7 @@ module.exports = (deployer, network, accounts) => {
         collateralToken.address,
         [conditionOneId, conditionTwoId, conditionThreeId],
         1,
-        process.env.AMMFUNDING || 1e12,
+        process.env.AMMFUNDING || defaultAMMFunding,
         { from: accounts[0] }
       );
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2442,6 +2442,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
@@ -5111,6 +5117,385 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "ganache-cli": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.3.0.tgz",
+      "integrity": "sha512-8SyzfX2ipRVBx1fBZLg3j8I3E334U3Vazk5mEpYcWqnIjC2ace6jtOXHG4aTuAvSz3+HzQ8p8pRjOJxdDZ2pnQ==",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "source-map-support": "0.5.9",
+        "yargs": "11.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true
+        },
+        "buffer-from": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
     },
     "gauge": {
       "version": "2.7.4",
@@ -9912,6 +10297,16 @@
       "dev": true,
       "requires": {
         "aproba": "^1.1.1"
+      }
+    },
+    "run-with-testrpc": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/run-with-testrpc/-/run-with-testrpc-0.3.0.tgz",
+      "integrity": "sha512-G4mvZz0O9AaYyESVEWzaYTagooKtWajd6t4zC7qxPs06pIyhYYzNytmxapCH/5tfWgsRSNfZ+XJhYPBvYpIlaQ==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "ganache-cli": "^6.0.3"
       }
     },
     "rxjs": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "migrate": "truffle compile --all && truffle migrate --reset",
     "test": "truffle test --network test",
     "test-app": "jest",
-    "start": "cd ./app && webpack-dev-server --config ./webpack.config.js --mode development",
+    "start": "run-with-testrpc -d \"npm run migrate && cd ./app && webpack-dev-server --config ./webpack.config.js --mode development\"",
     "build": "NODE_ENV=production cd ./app && webpack -p --config ./webpack.config.js --mode production"
   },
   "keywords": [
@@ -68,6 +68,7 @@
     "prettier": "^1.15.3",
     "react-hot-loader": "^4.6.3",
     "rlp": "^2.2.1",
+    "run-with-testrpc": "^0.3.0",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",
     "truffle": "^5.0.0",


### PR DESCRIPTION
1. AMMFUNDING has actually been 1 wei by default. This causes lots of NaNs to occur client-side. While it might be a good idea to address this, maybe not yet. I chose to default the funding value to 10 ETH instead.
2. AMM was configured with .0001% fees, which caused OOG because the frontend was asked to complete a transaction it couldn't estimate gas costs for because the transaction would have reverted because not enough was set aside for the transaction, thus causing the transaction to default to 90k gas and subsequently run out. This has been corrected. I still don't know why it was fine for stuff less than an ETH though. That decimal point really seemed to have made all the difference???
3. `npm start` is standalone. Dunno if you want this or not: I can easily take this commit out.