### PR TITLE
Redeem your stuff

### DIFF
--- a/app/src/buy-section.js
+++ b/app/src/buy-section.js
@@ -166,6 +166,8 @@ const BuySection = ({
     marketSelections
   ]);
 
+  const marketStage = lmsrState && lmsrState.stage;
+
   let hasAnyAllowance = false;
   let hasEnoughAllowance = false;
   let hasInfiniteAllowance = false;
@@ -235,58 +237,67 @@ const BuySection = ({
           collateral
         )}`}</p>
       )}
-      {lmsrAllowance != null && (
-        <p>{`Market maker allowance: ${
-          hasInfiniteAllowance
-            ? `∞ ${collateral.symbol}`
-            : formatCollateral(lmsrAllowance, collateral)
-        }`}</p>
-      )}
-      <input
-        type="text"
-        placeholder={`Investment amount in ${collateral.name}`}
-        value={investmentAmount}
-        onChange={e => {
-          setInvestmentAmount(e.target.value);
-        }}
-      />
-      <button
-        type="button"
-        disabled={
-          !hasEnoughAllowance ||
-          stagedTransactionType !== "buy outcome tokens" ||
-          stagedTradeAmounts == null ||
-          ongoingTransactionType != null ||
-          error != null
-        }
-        onClick={asWrappedTransaction(
-          "buy outcome tokens",
-          buyOutcomeTokens,
-          setError
-        )}
-      >
-        {ongoingTransactionType === "buy outcome tokens" ? (
-          <Spinner centered inverted width={25} height={25} />
-        ) : (
-          <>Buy</>
-        )}
-      </button>
-      {((!hasAnyAllowance && stagedTradeAmounts == null) ||
-        !hasEnoughAllowance) && (
-        <button
-          type="button"
-          onClick={asWrappedTransaction(
-            "set allowance",
-            setAllowance,
-            setError
+      {marketStage === "Closed" ? (
+        <p>Market maker is closed.</p>
+      ) : (
+        <>
+          {lmsrAllowance != null && (
+            <p>{`Market maker allowance: ${
+              hasInfiniteAllowance
+                ? `∞ ${collateral.symbol}`
+                : formatCollateral(lmsrAllowance, collateral)
+            }`}</p>
           )}
-        >
-          {ongoingTransactionType === "set allowance" ? (
-            <Spinner centered inverted width={25} height={25} />
-          ) : (
-            "Approve Market Maker for Trades"
+          <input
+            type="text"
+            placeholder={`Investment amount in ${collateral.name}`}
+            value={investmentAmount}
+            onChange={e => {
+              setInvestmentAmount(e.target.value);
+            }}
+          />
+          <button
+            type="button"
+            disabled={
+              !hasEnoughAllowance ||
+              stagedTransactionType !== "buy outcome tokens" ||
+              stagedTradeAmounts == null ||
+              ongoingTransactionType != null ||
+              marketStage !== "Running" ||
+              error != null
+            }
+            onClick={asWrappedTransaction(
+              "buy outcome tokens",
+              buyOutcomeTokens,
+              setError
+            )}
+          >
+            {ongoingTransactionType === "buy outcome tokens" ? (
+              <Spinner centered inverted width={25} height={25} />
+            ) : marketStage === "Paused" ? (
+              <>[Market paused]</>
+            ) : (
+              <>Buy</>
+            )}
+          </button>
+          {((!hasAnyAllowance && stagedTradeAmounts == null) ||
+            !hasEnoughAllowance) && (
+            <button
+              type="button"
+              onClick={asWrappedTransaction(
+                "set allowance",
+                setAllowance,
+                setError
+              )}
+            >
+              {ongoingTransactionType === "set allowance" ? (
+                <Spinner centered inverted width={25} height={25} />
+              ) : (
+                "Approve Market Maker for Trades"
+              )}
+            </button>
           )}
-        </button>
+        </>
       )}
       {error && (
         <span className={cn("error")}>
@@ -358,7 +369,8 @@ BuySection.propTypes = {
   lmsrState: PropTypes.shape({
     funding: PropTypes.instanceOf(BN).isRequired,
     positionBalances: PropTypes.arrayOf(PropTypes.instanceOf(BN).isRequired)
-      .isRequired
+      .isRequired,
+    stage: PropTypes.string.isRequired
   }),
   lmsrAllowance: PropTypes.instanceOf(BN),
   marketSelections: PropTypes.arrayOf(

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -411,6 +411,7 @@ Promise.all([
                   account,
                   pmSystem,
                   markets,
+                  marketResolutionStates,
                   positions,
                   collateral,
                   lmsrMarketMaker,

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -13,7 +13,7 @@ async function loadWeb3() {
   return web3;
 }
 
-async function loadBasicData(web3) {
+async function loadBasicData(web3, Decimal) {
   const { soliditySha3 } = web3.utils;
 
   const [
@@ -57,6 +57,8 @@ async function loadBasicData(web3) {
   collateral.name = await collateral.contract.name();
   collateral.symbol = await collateral.contract.symbol();
   collateral.decimals = (await collateral.contract.decimals()).toNumber();
+  collateral.toUnitsMultiplier = new Decimal(10).pow(collateral.decimals);
+  collateral.fromUnitsMultiplier = new Decimal(10).pow(-collateral.decimals);
 
   collateral.isWETH =
     collateral.name === "Wrapped Ether" &&
@@ -273,7 +275,7 @@ Promise.all([
 
       useEffect(() => {
         loadWeb3()
-          .then(web3 => (setWeb3(web3), loadBasicData(web3)))
+          .then(web3 => (setWeb3(web3), loadBasicData(web3, Decimal)))
           .then(
             ({ pmSystem, lmsrMarketMaker, collateral, markets, positions }) => {
               setPMSystem(pmSystem);

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -89,6 +89,7 @@ async function loadBasicData(web3) {
         }`
       );
 
+    market.marketIndex = i;
     market.conditionId = conditionId;
     market.outcomes.forEach((outcome, i) => {
       outcome.collectionId = soliditySha3(
@@ -110,7 +111,7 @@ async function loadBasicData(web3) {
     ...markets
       .slice()
       .reverse()
-      .map(({ conditionId, outcomes }, marketIndex) =>
+      .map(({ conditionId, outcomes, marketIndex }) =>
         outcomes.map((outcome, outcomeIndex) => ({
           ...outcome,
           conditionId,

--- a/app/src/market.js
+++ b/app/src/market.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import Web3 from "web3";
 import Decimal from "decimal.js-light";
@@ -18,6 +18,7 @@ const Market = ({
   resolutionDate,
   outcomes,
 
+  lmsrState,
   resolutionState,
 
   probabilities,
@@ -26,7 +27,9 @@ const Market = ({
   marketSelection,
   setMarketSelection
 }) => {
+  const marketStage = lmsrState && lmsrState.stage;
   const isResolved = resolutionState && resolutionState.isResolved;
+
   let resultOutcomeIndex = null;
   if (isResolved) {
     resultOutcomeIndex = resolutionState.payoutNumerators.findIndex(n =>
@@ -42,61 +45,43 @@ const Market = ({
     }
   }
 
-  useEffect(() => {
-    // If any condition has been resolved to having one outcome slot being the reported outcome,
-    // we want to make sure that the condition is not assumed either way
-    // so that probability estimates for the unresolved conditions will be accurate.
-
-    // We also select the reported outcome for future trades so that
-    // any trades after the report will be "discounted" for the user depending on how uncertain
-    // the market maker is until the market maker gets closed.
-    if (resultOutcomeIndex != null) {
-      setMarketSelection({
-        selectedOutcomeIndex: resultOutcomeIndex,
-        isAssumed: false
-      });
-    }
-  }, [resultOutcomeIndex]);
-
   return (
     <article className={cn("market")}>
       <section className={cn("title-section")}>
         <h1 className={cn("title")}>{title}</h1>
         <div className={cn("title-infos")}>
+          {marketStage !== "Closed" && (
+            <div className={cn("title-info")}>
+              <h2 className={cn("label")}>probability</h2>
+              <h2 className={cn("value")}>
+                {probabilities == null ? (
+                  <Spinner width={25} height={25} />
+                ) : (
+                  formatProbability(probabilities[0])
+                )}
+              </h2>
+            </div>
+          )}
           {isResolved ? (
-            <>
-              <div className={cn("title-info")}>
-                <h2 className={cn("label")}>reported outcome</h2>
-                <h2 className={cn("value", "centered")}>
-                  {resultOutcomeIndex != null
-                    ? outcomes[resultOutcomeIndex].title
-                    : "Mixed"}
-                </h2>
-              </div>
-            </>
+            <div className={cn("title-info")}>
+              <h2 className={cn("label")}>reported outcome</h2>
+              <h2 className={cn("value", "centered")}>
+                {resultOutcomeIndex != null
+                  ? outcomes[resultOutcomeIndex].title
+                  : "Mixed"}
+              </h2>
+            </div>
           ) : (
-            <>
-              <div className={cn("title-info")}>
-                <h2 className={cn("label")}>probability</h2>
-                <h2 className={cn("value")}>
-                  {probabilities == null ? (
-                    <Spinner width={25} height={25} />
-                  ) : (
-                    formatProbability(probabilities[0])
-                  )}
-                </h2>
-              </div>
-              <div className={cn("title-info")}>
-                <h2 className={cn("label")}>resolves</h2>
-                <h2 className={cn("value")}>
-                  {new Date(resolutionDate).toLocaleString()}
-                </h2>
-              </div>
-            </>
+            <div className={cn("title-info")}>
+              <h2 className={cn("label")}>resolves</h2>
+              <h2 className={cn("value")}>
+                {new Date(resolutionDate).toLocaleString()}
+              </h2>
+            </div>
           )}
         </div>
       </section>
-      {!isResolved && (
+      {marketStage !== "Closed" && (
         <>
           <section className={cn("outcomes-section")}>
             <OutcomesBinary
@@ -134,10 +119,12 @@ Market.propTypes = {
     }).isRequired
   ).isRequired,
 
+  lmsrState: PropTypes.shape({
+    stage: PropTypes.string.isRequired
+  }),
   resolutionState: PropTypes.shape({
     isResolved: PropTypes.bool.isRequired,
     payoutNumerators: PropTypes.arrayOf(PropTypes.instanceOf(BN).isRequired)
-      .isRequired
   }),
 
   probabilities: PropTypes.arrayOf(PropTypes.instanceOf(Decimal)),

--- a/app/src/market.js
+++ b/app/src/market.js
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
+import Web3 from "web3";
 import Decimal from "decimal.js-light";
 import OutcomesBinary from "./outcomes-binary";
 import OutcomeSelection from "./outcome-selection";
@@ -8,6 +9,8 @@ import { formatProbability } from "./utils/formatting";
 
 import cn from "classnames";
 
+const { BN } = Web3.utils;
+
 const Market = ({
   conditionId,
 
@@ -15,31 +18,65 @@ const Market = ({
   resolutionDate,
   outcomes,
 
+  resolutionState,
+
   probabilities,
   stagedProbabilities,
 
   marketSelection,
   setMarketSelection
 }) => {
-  const isResolved = false;
-  const disabled = false;
-  const result = null;
+  const isResolved = resolutionState && resolutionState.isResolved;
+  let resultOutcomeIndex = null;
+  if (isResolved) {
+    resultOutcomeIndex = resolutionState.payoutNumerators.findIndex(n =>
+      n.gtn(0)
+    );
+    if (
+      resolutionState.payoutNumerators.some(
+        (n, i) => resultOutcomeIndex !== i && n.gtn(0)
+      )
+    ) {
+      // there can only be one nonzero numerator for the result outcome index to be well defined
+      resultOutcomeIndex = null;
+    }
+  }
+
+  useEffect(() => {
+    // If any condition has been resolved to having one outcome slot being the reported outcome,
+    // we want to make sure that the condition is not assumed either way
+    // so that probability estimates for the unresolved conditions will be accurate.
+
+    // We also select the reported outcome for future trades so that
+    // any trades after the report will be "discounted" for the user depending on how uncertain
+    // the market maker is until the market maker gets closed.
+    if (resultOutcomeIndex != null) {
+      setMarketSelection({
+        selectedOutcomeIndex: resultOutcomeIndex,
+        isAssumed: false
+      });
+    }
+  }, [resultOutcomeIndex]);
 
   return (
-    <article className={cn("market", { disabled })}>
+    <article className={cn("market")}>
       <section className={cn("title-section")}>
         <h1 className={cn("title")}>{title}</h1>
         <div className={cn("title-infos")}>
-          <div className={cn("title-info")}>
-            {isResolved ? (
-              <>
-                <h2 className={cn("label")}>winning outcome</h2>
+          {isResolved ? (
+            <>
+              <div className={cn("title-info")}>
+                <h2 className={cn("label")}>reported outcome</h2>
                 <h2 className={cn("value", "centered")}>
-                  {outcomes[result].title}
+                  {resultOutcomeIndex != null
+                    ? outcomes[resultOutcomeIndex].title
+                    : "Mixed"}
                 </h2>
-              </>
-            ) : (
-              <>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className={cn("title-info")}>
                 <h2 className={cn("label")}>probability</h2>
                 <h2 className={cn("value")}>
                   {probabilities == null ? (
@@ -48,46 +85,39 @@ const Market = ({
                     formatProbability(probabilities[0])
                   )}
                 </h2>
-              </>
-            )}
-          </div>
-          {isResolved ? (
-            <div className={cn("title-info")}>
-              <h2 className={cn("label")}>market closed</h2>
-              <h2 className={cn("value")} />
-            </div>
-          ) : (
-            <div className={cn("title-info")}>
-              <h2 className={cn("label")}>resolves</h2>
-              <h2 className={cn("value")}>
-                {new Date(resolutionDate).toLocaleString()}
-              </h2>
-            </div>
+              </div>
+              <div className={cn("title-info")}>
+                <h2 className={cn("label")}>resolves</h2>
+                <h2 className={cn("value")}>
+                  {new Date(resolutionDate).toLocaleString()}
+                </h2>
+              </div>
+            </>
           )}
         </div>
       </section>
-      <section className={cn("outcomes-section")}>
-        <OutcomesBinary
-          {...{
-            outcomes,
-            probabilities,
-            stagedProbabilities,
-            isResolved
-          }}
-        />
-      </section>
-
       {!isResolved && (
-        <section className={cn("selection-section")}>
-          <OutcomeSelection
-            {...{
-              outcomes,
-              conditionId,
-              marketSelection,
-              setMarketSelection
-            }}
-          />
-        </section>
+        <>
+          <section className={cn("outcomes-section")}>
+            <OutcomesBinary
+              {...{
+                outcomes,
+                probabilities,
+                stagedProbabilities
+              }}
+            />
+          </section>
+          <section className={cn("selection-section")}>
+            <OutcomeSelection
+              {...{
+                outcomes,
+                conditionId,
+                marketSelection,
+                setMarketSelection
+              }}
+            />
+          </section>
+        </>
       )}
     </article>
   );
@@ -103,6 +133,12 @@ Market.propTypes = {
       title: PropTypes.string.isRequired
     }).isRequired
   ).isRequired,
+
+  resolutionState: PropTypes.shape({
+    isResolved: PropTypes.bool.isRequired,
+    payoutNumerators: PropTypes.arrayOf(PropTypes.instanceOf(BN).isRequired)
+      .isRequired
+  }),
 
   probabilities: PropTypes.arrayOf(PropTypes.instanceOf(Decimal)),
 

--- a/app/src/markets.js
+++ b/app/src/markets.js
@@ -4,6 +4,8 @@ import Web3 from "web3";
 import Decimal from "decimal.js-light";
 import Market from "./market";
 
+import { zeroDecimal, oneDecimal } from "./utils/constants";
+
 const { BN } = Web3.utils;
 
 function calcSelectedMarketProbabilitiesFromPositionProbabilities(
@@ -24,7 +26,7 @@ function calcSelectedMarketProbabilitiesFromPositionProbabilities(
       .reduce(
         (acc, { positionIndex }) =>
           acc.add(positionProbabilities[positionIndex]),
-        new Decimal(0)
+        zeroDecimal
       );
 
   const allConsideredPositionsProbability = sumConsideredPositionProbabilities(
@@ -32,9 +34,10 @@ function calcSelectedMarketProbabilitiesFromPositionProbabilities(
   );
   return markets.map(({ outcomes }, i) =>
     marketSelections != null && marketSelections[i].isAssumed
-      ? outcomes.map(
-          (_, j) =>
-            new Decimal(marketSelections[i].selectedOutcomeIndex === j ? 1 : 0)
+      ? outcomes.map((_, j) =>
+          marketSelections[i].selectedOutcomeIndex === j
+            ? oneDecimal
+            : zeroDecimal
         )
       : outcomes.map(({ positions }) =>
           sumConsideredPositionProbabilities(positions).div(
@@ -91,7 +94,7 @@ const Markets = ({
         (probability, i) =>
           probability.mul(stagedTradeAmounts[i].mul(invB).exp())
       );
-      const normalizer = new Decimal(1).div(
+      const normalizer = oneDecimal.div(
         unnormalizedPositionProbabilitiesAfterStagedTrade.reduce((a, b) =>
           a.add(b)
         )

--- a/app/src/markets.js
+++ b/app/src/markets.js
@@ -116,6 +116,7 @@ const Markets = ({
           key={market.conditionId}
           {...{
             ...market,
+            lmsrState,
             resolutionState:
               marketResolutionStates != null ? marketResolutionStates[i] : null,
             probabilities:

--- a/app/src/markets.js
+++ b/app/src/markets.js
@@ -46,6 +46,7 @@ function calcSelectedMarketProbabilitiesFromPositionProbabilities(
 
 const Markets = ({
   markets,
+  marketResolutionStates,
   positions,
   lmsrState,
   marketSelections,
@@ -115,6 +116,8 @@ const Markets = ({
           key={market.conditionId}
           {...{
             ...market,
+            resolutionState:
+              marketResolutionStates != null ? marketResolutionStates[i] : null,
             probabilities:
               marketProbabilities != null ? marketProbabilities[i] : null,
             stagedProbabilities:
@@ -143,6 +146,7 @@ Markets.propTypes = {
       conditionId: PropTypes.string.isRequired
     }).isRequired
   ).isRequired,
+  marketResolutionStates: PropTypes.array,
   positions: PropTypes.arrayOf(
     PropTypes.shape({
       positionIndex: PropTypes.number.isRequired,

--- a/app/src/outcomes-binary.js
+++ b/app/src/outcomes-binary.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Decimal from "decimal.js-light";
+import { oneDecimal, minDisplayedProbability } from "./utils/constants";
 import { formatProbability } from "./utils/formatting";
 
 import cn from "classnames";
@@ -10,16 +11,16 @@ const OutcomesBinary = ({ probabilities, stagedProbabilities }) => {
   const probability = probabilities != null ? probabilities[0] : null;
 
   let stagedProbability;
-  let predictedProbabilityDifference;
-  let absPredictedProbabilityDifference;
-  let displayPredictionProbability;
+  let stagedProbabilityDifference;
+  let absStagedProbabilityDifference;
+  let shouldDisplayStagedProbability;
   let estimatedHintPosition;
   if (stagedProbabilities != null) {
     stagedProbability = stagedProbabilities[0];
-    predictedProbabilityDifference = stagedProbability.sub(probability);
-    absPredictedProbabilityDifference = predictedProbabilityDifference.abs();
-    displayPredictionProbability = absPredictedProbabilityDifference.gte(
-      "0.0001"
+    stagedProbabilityDifference = stagedProbability.sub(probability);
+    absStagedProbabilityDifference = stagedProbabilityDifference.abs();
+    shouldDisplayStagedProbability = absStagedProbabilityDifference.gte(
+      minDisplayedProbability
     );
 
     estimatedHintPosition = probability.add(stagedProbability).mul(0.5);
@@ -42,7 +43,7 @@ const OutcomesBinary = ({ probabilities, stagedProbabilities }) => {
             </span>
           </div>
         </div>
-        {displayPredictionProbability && (
+        {shouldDisplayStagedProbability && (
           <div
             className={cn("prediction", {
               inverted: stagedProbability.lt(probability),
@@ -56,16 +57,16 @@ const OutcomesBinary = ({ probabilities, stagedProbabilities }) => {
                 ? formatProbability(probability)
                 : "auto",
               right: stagedProbability.lt(probability)
-                ? formatProbability(new Decimal(1).sub(probability))
+                ? formatProbability(oneDecimal.sub(probability))
                 : "auto",
-              width: formatProbability(absPredictedProbabilityDifference)
+              width: formatProbability(absStagedProbabilityDifference)
             }}
           >
-            {displayPredictionProbability && (
+            {shouldDisplayStagedProbability && (
               <div className={cn("hint")}>
                 <span className={cn("text")}>
                   <small>PREDICTED CHANGE</small>{" "}
-                  {formatProbability(predictedProbabilityDifference)}
+                  {formatProbability(stagedProbabilityDifference)}
                 </span>
               </div>
             )}

--- a/app/src/outcomes-binary.js
+++ b/app/src/outcomes-binary.js
@@ -5,7 +5,7 @@ import { formatProbability } from "./utils/formatting";
 
 import cn from "classnames";
 
-const OutcomesBinary = ({ probabilities, stagedProbabilities, isResolved }) => {
+const OutcomesBinary = ({ probabilities, stagedProbabilities }) => {
   const color = "lightblue";
   const probability = probabilities != null ? probabilities[0] : null;
 
@@ -18,14 +18,15 @@ const OutcomesBinary = ({ probabilities, stagedProbabilities, isResolved }) => {
     stagedProbability = stagedProbabilities[0];
     predictedProbabilityDifference = stagedProbability.sub(probability);
     absPredictedProbabilityDifference = predictedProbabilityDifference.abs();
-    displayPredictionProbability =
-      absPredictedProbabilityDifference.gte("0.0001") && !isResolved;
+    displayPredictionProbability = absPredictedProbabilityDifference.gte(
+      "0.0001"
+    );
 
     estimatedHintPosition = probability.add(stagedProbability).mul(0.5);
   }
 
   return (
-    <div className={cn("binary-outcome", { closed: isResolved })}>
+    <div className={cn("binary-outcome")}>
       <div className={cn("bar")} style={{ color }}>
         <div
           className={cn("inner")}
@@ -70,11 +71,6 @@ const OutcomesBinary = ({ probabilities, stagedProbabilities, isResolved }) => {
             )}
           </div>
         )}
-        {isResolved && (
-          <div className={cn("predictions-before-close")}>
-            <em>Final Predictions before market was resolved</em>
-          </div>
-        )}
       </div>
     </div>
   );
@@ -84,8 +80,7 @@ OutcomesBinary.propTypes = {
   probabilities: PropTypes.arrayOf(PropTypes.instanceOf(Decimal).isRequired),
   stagedProbabilities: PropTypes.arrayOf(
     PropTypes.instanceOf(Decimal).isRequired
-  ),
-  isResolved: PropTypes.bool.isRequired
+  )
 };
 
 export default OutcomesBinary;

--- a/app/src/utils/constants.js
+++ b/app/src/utils/constants.js
@@ -1,0 +1,16 @@
+import Web3 from "web3";
+
+import Decimal from "decimal.js-light";
+
+const { toBN } = Web3.utils;
+
+export const maxUint256BN = toBN(`0x${"ff".repeat(32)}`);
+
+export const zeroDecimal = new Decimal(0);
+export const oneDecimal = new Decimal(1);
+
+export const probabilityDecimalPlaces = 2;
+export const minDisplayedProbability = new Decimal(10)
+  .pow(-probabilityDecimalPlaces)
+  .mul("0.01");
+export const collateralSignificantDigits = 5;

--- a/app/src/utils/formatting.js
+++ b/app/src/utils/formatting.js
@@ -1,13 +1,20 @@
 import React from "react";
 import Decimal from "decimal.js-light";
 
+import {
+  probabilityDecimalPlaces,
+  collateralSignificantDigits
+} from "./constants";
+
 export const formatProbability = probability =>
-  `${probability.mul(100).toDecimalPlaces(2, Decimal.ROUND_HALF_UP)}%`;
+  `${probability
+    .mul(100)
+    .toDecimalPlaces(probabilityDecimalPlaces, Decimal.ROUND_HALF_UP)}%`;
 
 export const formatCollateral = (amount, collateral) => {
   return `${new Decimal((amount || "0").toString())
-    .mul(new Decimal(10).pow(-collateral.decimals))
-    .toSignificantDigits(5)
+    .mul(collateral.fromUnitsMultiplier)
+    .toSignificantDigits(collateralSignificantDigits)
     .toString()} ${collateral.symbol}`;
 };
 

--- a/app/src/utils/position-groups.js
+++ b/app/src/utils/position-groups.js
@@ -1,9 +1,8 @@
 import Web3 from "web3";
+import { maxUint256BN } from "./constants";
 import { product, combinations } from "./itertools";
 
 const { toBN, toHex, padLeft } = Web3.utils;
-
-const maxUint256 = Web3.utils.toBN(`0x${"ff".repeat(32)}`);
 
 export function calcPositionGroups(markets, positions, positionAmounts) {
   const positionGroups = [];
@@ -38,7 +37,7 @@ export function calcPositionGroups(markets, positions, positionAmounts) {
               ? accRunningAmount
               : runningPositionAmounts[positionIndex]
           ],
-          [maxUint256, maxUint256]
+          [maxUint256BN, maxUint256BN]
         );
 
         if (groupRunningAmount.gtn(0)) {

--- a/app/src/your-positions.js
+++ b/app/src/your-positions.js
@@ -4,6 +4,7 @@ import Web3 from "web3";
 import Decimal from "decimal.js-light";
 import PositionGroupDetails from "./position-group-details";
 import Spinner from "./spinner";
+import { zeroDecimal } from "./utils/constants";
 import { formatCollateral } from "./utils/formatting";
 import { calcPositionGroups } from "./utils/position-groups";
 
@@ -24,7 +25,7 @@ function calcNetCost({ funding, positionBalances }, tradeAmounts) {
             .mul(invB)
             .exp()
         ),
-      new Decimal(0)
+      zeroDecimal
     )
     .ln()
     .div(invB);
@@ -91,9 +92,7 @@ const YourPositions = ({
     }
 
     try {
-      const saleAmountInUnits = new Decimal(10)
-        .pow(collateral.decimals)
-        .mul(saleAmount);
+      const saleAmountInUnits = collateral.toUnitsMultiplier.mul(saleAmount);
 
       if (!saleAmountInUnits.isInteger())
         throw new Error(
@@ -114,7 +113,7 @@ const YourPositions = ({
           salePositionGroup.positions.find(
             ({ positionIndex }) => positionIndex === i
           ) == null
-            ? new Decimal(0)
+            ? zeroDecimal
             : saleAmountInUnits.neg()
       );
 
@@ -334,8 +333,7 @@ const YourPositions = ({
                         type="button"
                         onClick={() => {
                           setSaleAmount(
-                            new Decimal(10)
-                              .pow(-collateral.decimals)
+                            collateral.fromUnitsMultiplier
                               .mul(positionGroup.amount.toString())
                               .toFixed()
                           );

--- a/app/src/your-positions.js
+++ b/app/src/your-positions.js
@@ -155,6 +155,8 @@ const YourPositions = ({
     });
   }
 
+  const marketStage = lmsrState && lmsrState.stage;
+
   return (
     <div className={cn("your-positions")}>
       <h2>Positions</h2>
@@ -177,21 +179,23 @@ const YourPositions = ({
                     collateral
                   }}
                 />
-                <div className={cn("controls")}>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setSalePositionGroup(
-                        isSalePositionGroup ? null : positionGroup
-                      );
-                      setSaleAmount("");
-                    }}
-                  >
-                    Sell
-                  </button>
-                </div>
+                {marketStage !== "Closed" && (
+                  <div className={cn("controls")}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setSalePositionGroup(
+                          isSalePositionGroup ? null : positionGroup
+                        );
+                        setSaleAmount("");
+                      }}
+                    >
+                      Sell
+                    </button>
+                  </div>
+                )}
               </div>
-              {isSalePositionGroup && (
+              {isSalePositionGroup && marketStage !== "Closed" && (
                 <div className={cn("row", "sell")}>
                   <p>
                     You can sell a maximum amount of{" "}
@@ -226,6 +230,7 @@ const YourPositions = ({
                         stagedTradeAmounts == null ||
                         stagedTransactionType !== "sell outcome tokens" ||
                         ongoingTransactionType != null ||
+                        marketStage !== "Running" ||
                         error != null
                       }
                       onClick={asWrappedTransaction(
@@ -236,6 +241,8 @@ const YourPositions = ({
                     >
                       {ongoingTransactionType === "sell outcome tokens" ? (
                         <Spinner inverted width={25} height={25} />
+                      ) : marketStage === "Paused" ? (
+                        <>[Market paused]</>
                       ) : (
                         <>Confirm</>
                       )}
@@ -294,7 +301,8 @@ YourPositions.propTypes = {
   lmsrState: PropTypes.shape({
     funding: PropTypes.instanceOf(BN).isRequired,
     positionBalances: PropTypes.arrayOf(PropTypes.instanceOf(BN).isRequired)
-      .isRequired
+      .isRequired,
+    stage: PropTypes.string.isRequired
   }),
   positionBalances: PropTypes.arrayOf(PropTypes.instanceOf(BN).isRequired),
   stagedTradeAmounts: PropTypes.arrayOf(


### PR DESCRIPTION
Forgot to put back resolve/closed after the refactor... I took out the probabilities view after market close because the market maker contract would send all its assets back to the owner of the contract, and then it wouldn't be able to report any odds after that. Probabilities are separate from reported outcomes, so in fact people can get free money from the market maker if the contract is not closed before one of the markets resolves. Essentially resolved != closed.

Market index field for outcomes was borked in the internal rep too, ... that was my fault. I fixed it though.

Anyway, redeem is almost entirely lifted off of the recursive merge implementation in the market maker. I only implemented redeem for everything after all the markets are resolved.