### PR TITLE
Add travis release deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,19 @@ deploy:
     upload-dir: current
     on:
       branch: master
+
+  # Prepare legacy production deployment
+  - provider: s3
+    bucket: $STAGING_BUCKET_NAME
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    skip_cleanup: true
+    local_dir: docs
+    upload-dir: releases/$TRAVIS_TAG
+    on:
+      tags: true
+  - provider: script
+    script: bash travis/prepare_production_deployment.sh
+    on:
+      tags: true
+      node: '9'

--- a/travis/prepare_production_deployment.sh
+++ b/travis/prepare_production_deployment.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -ev
+
+# Only:
+# - Tagged commits
+# - Security env variables are available.
+if [ -n "$TRAVIS_TAG" ] && [ -n "$PROD_DEPLOYMENT_HOOK_TOKEN" ] && [ -n "$PROD_DEPLOYMENT_HOOK_URL" ]
+then
+  curl --silent --output /dev/null --write-out "%{http_code}" -X POST \
+     -F token="$PROD_DEPLOYMENT_HOOK_TOKEN" \
+     -F ref=master \
+     -F "variables[TRIGGER_RELEASE_COMMIT_TAG]=$TRAVIS_TAG" \
+      $PROD_DEPLOYMENT_HOOK_URL
+else
+  echo "[ERROR] Production deployment could not be prepared"
+fi


### PR DESCRIPTION
Add travis release deployment and shell script `travis/prepare_production_deployment.sh` to manage a manual production deployment.